### PR TITLE
Adding placeholders for complicated regexs

### DIFF
--- a/kuristo/actions/checks_regex.py
+++ b/kuristo/actions/checks_regex.py
@@ -3,13 +3,21 @@ from kuristo.registry import action
 from kuristo.actions.action import Action
 from kuristo.utils import interpolate_str
 
+ALIAS_PATTERNS = {
+    "float": r"([-+]?(?:\d*\.\d+|\d+)(?:[eE][-+]?\d+)?)",
+    "int": r"([-+]?\d+)",
+}
+
+ALIAS_RE = re.compile(r"{:(\w+):}")
+
 
 @action("checks/regex")
 class RegexCheck(Action):
+
     def __init__(self, name, context, **kwargs):
         super().__init__(name, context, **kwargs)
         self._target_step = kwargs["input"]
-        self._pattern = kwargs.get("pattern", [])
+        self._pattern = self._expand_pattern(kwargs.get("pattern", []))
 
     def run(self, context=None):
         output = self._resolve_output()
@@ -24,3 +32,11 @@ class RegexCheck(Action):
 
     def _resolve_output(self):
         return interpolate_str(self._target_step, self.context.vars)
+
+    def _expand_pattern(self, pattern: str) -> str:
+        def replacer(match):
+            name = match.group(1)
+            # fallback to original if not found
+            return ALIAS_PATTERNS.get(name, match.group(0))
+
+        return ALIAS_RE.sub(replacer, pattern)

--- a/tests/assets/tests4/ktests.yaml
+++ b/tests/assets/tests4/ktests.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: checks/regex-float
         with:
           input: ${{ steps.result.output }}
-          pattern: "Value: ([-+]?(?:\\d*\\.\\d+|\\d+)(?:[eE][-+]?\\d+)?)"
+          pattern: "Value: {:float:}"
           gold: 1.23456789
           rel_tol: 1e-5
 
@@ -27,6 +27,6 @@ jobs:
         uses: checks/regex-float
         with:
           input: ${{ steps.result.output }}
-          pattern: "Final: ([-+]?(?:\\d*\\.\\d+|\\d+)(?:[eE][-+]?\\d+)?)"
+          pattern: "Final: {:float:}"
           gold: 2.4
           abs_tol: 1e-10


### PR DESCRIPTION
- {:float:} to match a floating point number
- {:int:} to match an integer

Closes #5
