### PR TITLE
Console width is configurable

### DIFF
--- a/kuristo/config.py
+++ b/kuristo/config.py
@@ -28,7 +28,7 @@ class Config:
         self.batch_default_account = self._get("batch.default_account", None)
         self.batch_partition = self._get("batch.partition", None)
 
-        self.console_width = 100
+        self.console_width = self._get("base.console-width", 100)
 
     def _load(self):
         try:


### PR DESCRIPTION
Use `base.console-width` to set your preferred console width

closes #56
