### PR TITLE
Renaming snake_style params to kebab-style

### DIFF
--- a/.kuristo/config.yaml
+++ b/.kuristo/config.yaml
@@ -1,5 +1,5 @@
 base:
-  workflow_filename: ktests.yaml
+  workflow-filename: ktests.yaml
 
 log:
   history: 5

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ resources:
   num_cores: 8
 
 runner:
-  mpi_launcher: mpiexec
+  mpi-launcher: mpiexec
 ```
 
 Or override via environment variable:

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ You can define a global config at `.kuristo/config.yaml`:
 
 ```yaml
 resources:
-  num_cores: 8
+  num-cores: 8
 
 runner:
   mpi-launcher: mpiexec

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Set logging retention and cleanup in `config.yaml`:
 
 ```yaml
 log:
-  dir_name: .kuristo-out
+  dir-name: .kuristo-out
   history: 5
   cleanup: on_success
 ```

--- a/docs/actions/csv-diff.rst
+++ b/docs/actions/csv-diff.rst
@@ -27,7 +27,7 @@ Arguments
 ``test`` (string, required)
    Path to the generated output file.
 
-``abs_tol`` (float, optional)
+``abs-tol`` (float, optional)
    | Allowed absolute difference per value.
    | Default is ``1e-12``.
 

--- a/docs/actions/csv-diff.rst
+++ b/docs/actions/csv-diff.rst
@@ -31,7 +31,7 @@ Arguments
    | Allowed absolute difference per value.
    | Default is ``1e-12``.
 
-``rel_tol`` (float, optional)
+``rel-tol`` (float, optional)
    | Allowed relative difference per value.
    | Default is ``1e-6``.
 

--- a/docs/actions/regex-float.rst
+++ b/docs/actions/regex-float.rst
@@ -36,7 +36,7 @@ Arguments
 ``gold`` (float or list of floats, required)
    Reference value(s) to compare against.
 
-``abs_tol`` (float, optional)
+``abs-tol`` (float, optional)
    | Maximum absolute difference allowed.
    | Default is ``0.0``.
 

--- a/docs/actions/regex-float.rst
+++ b/docs/actions/regex-float.rst
@@ -21,7 +21,7 @@ Example Usage
          input: ${{ steps.result.output }}
          pattern: "Value: ([0-9\\.]+)"
          gold: 1.23456789
-         rel_tol: 1e-5
+         rel-tol: 1e-5
 
 
 Arguments
@@ -40,7 +40,7 @@ Arguments
    | Maximum absolute difference allowed.
    | Default is ``0.0``.
 
-``rel_tol`` (float, optional)
+``rel-tol`` (float, optional)
    | Maximum relative difference allowed.
    | Default is ``1e-8``.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -42,7 +42,7 @@ Runner
 ``runner:``
    Main runner settings.
 
-``runner.mpi_launcher``
+``runner.mpi-launcher``
    MPI command used to launch jobs.
 
    Default value: ``mpirun``
@@ -79,7 +79,7 @@ And we want to keep 10 previous runs.
       history: 10
 
    runner:
-      mpi_launcher: mpiexec
+      mpi-launcher: mpiexec
 
    batch:
       backend: slurm

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -11,7 +11,7 @@ Basic options
 ``base:``
    Logging settings section.
 
-``workflow_filename``
+``workflow-filename``
    Name of files that contain workflow descriptions.
    These files are looked for whne we have kuristo execute workflows from a location.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -57,7 +57,7 @@ Batch
 ``batch.backend``
    Which batch system to use (e.g., slurm).
 
-``batch.default_account``
+``batch.default-account``
    Currently, does nothing.
 
 ``batch.partition``

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -24,7 +24,7 @@ Logging options
 ``log:``
    Logging settings section.
 
-``log.dir_name``
+``log.dir-name``
    Directory where logs will be stored.
 
 ``log.history``

--- a/kuristo/actions/action.py
+++ b/kuristo/actions/action.py
@@ -17,7 +17,7 @@ class Action(ABC):
             self._name = name
         self._output = None
         self._context = context
-        self._timeout_minutes = kwargs.get("timeout_minutes", 60)
+        self._timeout_minutes = kwargs.get("timeout-minutes", 60)
 
     @property
     def name(self):

--- a/kuristo/actions/checks_cvsdiff.py
+++ b/kuristo/actions/checks_cvsdiff.py
@@ -14,7 +14,7 @@ class CSVDiffCheck(Action):
         self._columns = kwargs.get("columns", "all")
         self._tolerances = kwargs.get("tolerances", {})
 
-        self._default_rel = float(kwargs.get("rel_tol", 1e-6))
+        self._default_rel = float(kwargs.get("rel-tol", 1e-6))
         self._default_abs = float(kwargs.get("abs_tol", 1e-12))
 
     def run(self, context=None):
@@ -30,7 +30,7 @@ class CSVDiffCheck(Action):
                     g_val = float(gold_data[row_idx][col])
                     t_val = float(test_data[row_idx][col])
 
-                    rel = float(self._tolerances.get(col, {}).get("rel_tol", self._default_rel))
+                    rel = float(self._tolerances.get(col, {}).get("rel-tol", self._default_rel))
                     abs_ = float(self._tolerances.get(col, {}).get("abs_tol", self._default_abs))
 
                     if not math.isclose(g_val, t_val, rel_tol=rel, abs_tol=abs_):

--- a/kuristo/actions/checks_cvsdiff.py
+++ b/kuristo/actions/checks_cvsdiff.py
@@ -15,7 +15,7 @@ class CSVDiffCheck(Action):
         self._tolerances = kwargs.get("tolerances", {})
 
         self._default_rel = float(kwargs.get("rel-tol", 1e-6))
-        self._default_abs = float(kwargs.get("abs_tol", 1e-12))
+        self._default_abs = float(kwargs.get("abs-tol", 1e-12))
 
     def run(self, context=None):
         gold_data = self._read_csv(self._gold_path)
@@ -31,13 +31,13 @@ class CSVDiffCheck(Action):
                     t_val = float(test_data[row_idx][col])
 
                     rel = float(self._tolerances.get(col, {}).get("rel-tol", self._default_rel))
-                    abs_ = float(self._tolerances.get(col, {}).get("abs_tol", self._default_abs))
+                    abs_ = float(self._tolerances.get(col, {}).get("abs-tol", self._default_abs))
 
                     if not math.isclose(g_val, t_val, rel_tol=rel, abs_tol=abs_):
                         self._stdout = (
                             f"Mismatch at row {row_idx}, column '{col}': "
                             f"gold={g_val}, test={t_val} "
-                            f"(rel_tol={rel}, abs_tol={abs_})"
+                            f"(rel_tol={rel}, abs-tol={abs_})"
                         )
                         self._return_code = -1
                         self._stdout = self._stdout.encode()

--- a/kuristo/actions/checks_regex_float.py
+++ b/kuristo/actions/checks_regex_float.py
@@ -10,7 +10,7 @@ class RegexFloatCheck(RegexCheck):
         super().__init__(name, context, **kwargs)
         self._gold = float(kwargs["gold"])
         self._rel_tol = float(kwargs.get("rel-tol", 1e-8))
-        self._abs_tol = float(kwargs.get("abs_tol", 0.0))
+        self._abs_tol = float(kwargs.get("abs-tol", 0.0))
 
     def run(self, context=None):
         output = self._resolve_output()
@@ -29,7 +29,7 @@ class RegexFloatCheck(RegexCheck):
                 else:
                     self._stdout = (
                         f"Regex float check failed: got {value}, expected {self._gold}, "
-                        f"rel-tol={self._rel_tol}, abs_tol={self._abs_tol}"
+                        f"rel-tol={self._rel_tol}, abs-tol={self._abs_tol}"
                     )
                     self._return_code = -1
             except ValueError:

--- a/kuristo/actions/checks_regex_float.py
+++ b/kuristo/actions/checks_regex_float.py
@@ -9,7 +9,7 @@ class RegexFloatCheck(RegexCheck):
     def __init__(self, name, context, **kwargs):
         super().__init__(name, context, **kwargs)
         self._gold = float(kwargs["gold"])
-        self._rel_tol = float(kwargs.get("rel_tol", 1e-8))
+        self._rel_tol = float(kwargs.get("rel-tol", 1e-8))
         self._abs_tol = float(kwargs.get("abs_tol", 0.0))
 
     def run(self, context=None):
@@ -29,7 +29,7 @@ class RegexFloatCheck(RegexCheck):
                 else:
                     self._stdout = (
                         f"Regex float check failed: got {value}, expected {self._gold}, "
-                        f"rel_tol={self._rel_tol}, abs_tol={self._abs_tol}"
+                        f"rel-tol={self._rel_tol}, abs_tol={self._abs_tol}"
                     )
                     self._return_code = -1
             except ValueError:

--- a/kuristo/actions/mpi_action.py
+++ b/kuristo/actions/mpi_action.py
@@ -15,7 +15,7 @@ class MPIAction(ProcessAction):
             context=context,
             **kwargs,
         )
-        self._n_ranks = kwargs.get("n_procs", 1)
+        self._n_ranks = kwargs.get("n-procs", 1)
 
     @property
     def num_cores(self):

--- a/kuristo/actions/seq_action.py
+++ b/kuristo/actions/seq_action.py
@@ -15,7 +15,7 @@ class SeqAction(ProcessAction):
             context=context,
             **kwargs
         )
-        self._n_cores = kwargs.get("n_cores", 1)
+        self._n_cores = kwargs.get("n-cores", 1)
 
     @property
     def num_cores(self):

--- a/kuristo/config.py
+++ b/kuristo/config.py
@@ -22,7 +22,7 @@ class Config:
         self.log_cleanup = self._get("log.cleanup", "always")
         self.num_cores = self._resolve_cores()
 
-        self.mpi_launcher = os.getenv("KURISTO_MPI_LAUNCHER", self._get("runner.mpi_launcher", "mpirun"))
+        self.mpi_launcher = os.getenv("KURISTO_MPI_LAUNCHER", self._get("runner.mpi-launcher", "mpirun"))
 
         self.batch_backend = self._get("batch.backend", None)
         self.batch_default_account = self._get("batch.default-account", None)

--- a/kuristo/config.py
+++ b/kuristo/config.py
@@ -16,7 +16,7 @@ class Config:
 
         self.workflow_filename = self._get("base.workflow-filename", "kuristo.yaml")
 
-        self.log_dir = (self._config_dir.parent / self._get("log.dir_name", ".kuristo-out")).resolve()
+        self.log_dir = (self._config_dir.parent / self._get("log.dir-name", ".kuristo-out")).resolve()
         self.log_history = int(self._get("log.history", 5))
         # Options: on_success, always, never
         self.log_cleanup = self._get("log.cleanup", "always")

--- a/kuristo/config.py
+++ b/kuristo/config.py
@@ -25,7 +25,7 @@ class Config:
         self.mpi_launcher = os.getenv("KURISTO_MPI_LAUNCHER", self._get("runner.mpi_launcher", "mpirun"))
 
         self.batch_backend = self._get("batch.backend", None)
-        self.batch_default_account = self._get("batch.default_account", None)
+        self.batch_default_account = self._get("batch.default-account", None)
         self.batch_partition = self._get("batch.partition", None)
 
         self.console_width = self._get("base.console-width", 100)

--- a/kuristo/config.py
+++ b/kuristo/config.py
@@ -48,14 +48,14 @@ class Config:
 
     def _resolve_cores(self) -> int:
         system_default = get_default_core_limit()
-        value = self._get("resources.num_cores", system_default)
+        value = self._get("resources.num-cores", system_default)
 
         try:
             value = int(value)
             if value <= 0 or value > os.cpu_count():
                 raise ValueError
         except ValueError:
-            print(f"Invalid 'resources.num_cores' value: {value}, falling back to system default ({system_default})")
+            print(f"Invalid 'resources.num-cores' value: {value}, falling back to system default ({system_default})")
             return system_default
 
         return value

--- a/kuristo/config.py
+++ b/kuristo/config.py
@@ -14,7 +14,7 @@ class Config:
         self.path = Path(path or self._config_dir / "config.yaml")
         self._data = self._load()
 
-        self.workflow_filename = self._get("base.workflow_filename", "kuristo.yaml")
+        self.workflow_filename = self._get("base.workflow-filename", "kuristo.yaml")
 
         self.log_dir = (self._config_dir.parent / self._get("log.dir_name", ".kuristo-out")).resolve()
         self.log_history = int(self._get("log.history", 5))

--- a/tests/assets/tests1/folder_a/ktests.yaml
+++ b/tests/assets/tests1/folder_a/ktests.yaml
@@ -5,4 +5,4 @@ jobs:
       - name: 4 cores
         uses: core/sequential
         with:
-          n_cores: 4
+          n-cores: 4

--- a/tests/assets/tests2/ktests.yaml
+++ b/tests/assets/tests2/ktests.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: 10k cores
         uses: core/sequential
         with:
-          n_cores: 1000000
+          n-cores: 1000000
 
   test-skipped:
     description: "Disabled test"

--- a/tests/assets/tests2/ktests.yaml
+++ b/tests/assets/tests2/ktests.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: MPI-2 (a)
         uses: app-name/mpi
         with:
-          n_procs: 2
+          n-procs: 2
 
   test-C:
     description: "Another test that will use 4 MPI ranks"
@@ -20,7 +20,7 @@ jobs:
       - name: MPI-2 (b)
         uses: app-name/mpi
         with:
-          n_procs: 2
+          n-procs: 2
 
   test-oversized:
     description: "Oversized test that should never be scheduled"

--- a/tests/assets/tests4/ktests.yaml
+++ b/tests/assets/tests4/ktests.yaml
@@ -13,7 +13,7 @@ jobs:
           input: ${{ steps.result.output }}
           pattern: "Value: {:float:}"
           gold: 1.23456789
-          rel_tol: 1e-5
+          rel-tol: 1e-5
 
       - name: Check wrong number
         uses: checks/regex-float

--- a/tests/assets/tests4/ktests.yaml
+++ b/tests/assets/tests4/ktests.yaml
@@ -21,7 +21,7 @@ jobs:
           input: ${{ steps.result.output }}
           pattern: "Value: ([0-9\\.]+)"
           gold: 2.4
-          abs_tol: 1e-10
+          abs-tol: 1e-10
 
       - name: Check user error
         uses: checks/regex-float
@@ -29,4 +29,4 @@ jobs:
           input: ${{ steps.result.output }}
           pattern: "Final: {:float:}"
           gold: 2.4
-          abs_tol: 1e-10
+          abs-tol: 1e-10

--- a/tests/test_mpi_action.py
+++ b/tests/test_mpi_action.py
@@ -21,7 +21,7 @@ def test_default_num_cores():
 
 def test_custom_num_cores():
     ctx = make_context()
-    action = DummyMPIAction(name="mpi_test", context=ctx, n_procs=8)
+    action = DummyMPIAction(name="mpi_test", context=ctx, **{'n-procs': 8})
     assert action.num_cores == 8
 
 
@@ -29,7 +29,7 @@ def test_custom_num_cores():
 def test_create_command_uses_config_and_sub_command(mock_get):
     ctx = make_context()
     mock_get.return_value = MagicMock(mpi_launcher="mpirun")
-    action = DummyMPIAction(name="mpi_test", context=ctx, n_procs=4)
+    action = DummyMPIAction(name="mpi_test", context=ctx, **{'n-procs': 4})
 
     result = action.create_command()
 

--- a/tests/test_seq_action.py
+++ b/tests/test_seq_action.py
@@ -16,7 +16,7 @@ def test_default_num_cores():
 
 def test_custom_num_cores():
     ctx = make_context()
-    action = SeqAction(name="test_seq", context=ctx, n_cores=4)
+    action = SeqAction(name="test_seq", context=ctx, **{'n-cores': 4})
     assert action.num_cores == 4
 
 


### PR DESCRIPTION
- Renaming config parameter: workflow_filename -> workflow-filename
- Renaming config parameter: batch.default_account -> batch.default-account
- Renaming config parameter: mpi_launcher -> mpi-launcher
- Renaming config parameter: dir_name -> dir-name
- Renaming config parameter: num_cores -> num-cores
- Fixing left-over from renaming timeout_minutes to timeout-minutes
- Renaming parameter: rel_tol to rel-tol
- Renaming parameter: abs_tol to abs-tol
- Renaming parameter: n_procs -> n-procs
- Renaming parameter: n_cores -> n-cores
