### PR TITLE
Removing `--report` flag from `run` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,14 +145,6 @@ log:
   cleanup: on_success
 ```
 
-## Job Timing Report
-
-To output a CSV of job timings:
-
-```bash
-kuristo run tests --report timing.csv
-```
-
 ## Configuration
 
 You can define a global config at `.kuristo/config.yaml`:

--- a/extras/completions/_kuristo
+++ b/extras/completions/_kuristo
@@ -36,7 +36,6 @@ case $state in
         _arguments \
           '--help[Show help message and exit]' \
           '--verbose[Verbose level]:int' \
-          '--report[Save report to a CSV file]:file:_files' \
           '*:Locations to scan:_files'
         ;;
       doctor)

--- a/kuristo/cli/__init__.py
+++ b/kuristo/cli/__init__.py
@@ -34,7 +34,6 @@ def build_parser():
     # Run command
     run_parser = subparsers.add_parser("run", help="Run jobs")
     run_parser.add_argument("--verbose", "-v", type=int, default=0, help="Verbose level")
-    run_parser.add_argument("--report", type=Path, help="Save report with the runtime information to a CSV file")
     run_parser.add_argument("locations", nargs="*", help="Locations to scan for workflow files")
 
     # Doctor command

--- a/kuristo/cli/_run.py
+++ b/kuristo/cli/_run.py
@@ -10,22 +10,6 @@ from kuristo.job_spec import parse_workflow_files
 from kuristo.scanner import scan_locations
 
 
-def write_report_csv(csv_path: Path, jobs):
-    import csv
-    with open(csv_path, "w", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerow(["id", "job name", "status", "duration [s]", "return code"])
-        for job in jobs:
-            duration = "" if job.is_skipped else round(job.elapsed_time, 3)
-            if job.is_skipped:
-                status = "skipped"
-            elif job.return_code == 0:
-                status = "success"
-            else:
-                status = "failed"
-            writer.writerow([job.num, job.name, status, duration, job.return_code])
-
-
 def create_results(jobs):
     """
     Built results from jobs. Jobs must be finished.
@@ -82,8 +66,5 @@ def run_jobs(args):
     results = create_results(scheduler.jobs)
     yaml_path = out_dir / "report.yaml"
     write_report_yaml(yaml_path, results, scheduler.total_runtime)
-
-    if args.report:
-        write_report_csv(args.report_path, scheduler.jobs)
 
     return scheduler.exit_code()


### PR DESCRIPTION
This is/will be replaced by the `report` command
