### PR TITLE
Fixing most of the mess with output in actions

### DIFF
--- a/kuristo/actions/action.py
+++ b/kuristo/actions/action.py
@@ -45,11 +45,16 @@ class Action(ABC):
         if self._output:
             return self._output
         else:
-            return b''
+            return ''
 
     @output.setter
-    def output(self, str):
-        self._output = str
+    def output(self, out):
+        if isinstance(out, str):
+            self._output = out
+        elif isinstance(out, bytes):
+            self._output = out.decode()
+        else:
+            self._output = str(out)
 
     @property
     def timeout_minutes(self):

--- a/kuristo/actions/checks_cvsdiff.py
+++ b/kuristo/actions/checks_cvsdiff.py
@@ -34,19 +34,18 @@ class CSVDiffCheck(Action):
                     abs_ = float(self._tolerances.get(col, {}).get("abs-tol", self._default_abs))
 
                     if not math.isclose(g_val, t_val, rel_tol=rel, abs_tol=abs_):
-                        self._stdout = (
+                        self.output = (
                             f"Mismatch at row {row_idx}, column '{col}': "
                             f"gold={g_val}, test={t_val} "
                             f"(rel_tol={rel}, abs-tol={abs_})"
                         )
-                        self._stdout = self._stdout.encode()
                         return -1
 
-            self._output = b"CSV files match within tolerance."
+            self.output = "CSV files match within tolerance."
             return 0
 
         except Exception as ex:
-            self._output = f"Comparison failed: {ex}".encode()
+            self.output = f"Comparison failed: {ex}"
             return -1
 
     def _read_csv(self, path):

--- a/kuristo/actions/checks_regex_float.py
+++ b/kuristo/actions/checks_regex_float.py
@@ -15,21 +15,21 @@ class RegexFloatCheck(RegexCheck):
         try:
             value = float(match.group(1))
             if math.isclose(value, self._gold, rel_tol=self._rel_tol, abs_tol=self._abs_tol):
-                self._stdout = (
+                self.output = (
                     f"Regex float check passed: got {value}, expected {self._gold}"
                 )
                 return 0
             else:
-                self._stdout = (
+                self.output = (
                     f"Regex float check failed: got {value}, expected {self._gold}, "
                     f"rel-tol={self._rel_tol}, abs-tol={self._abs_tol}"
                 )
                 return -1
         except ValueError:
-            self._stdout = (
+            self.output = (
                 f"Regex matched value '{match.group(1)}' but it is not a float."
             )
             return -1
 
     def on_failure(self):
-        self._stdout = f"Pattern '{self.pattern}' not found in output"
+        self.output = f"Pattern '{self.pattern}' not found in output"

--- a/kuristo/actions/composite_action.py
+++ b/kuristo/actions/composite_action.py
@@ -20,7 +20,7 @@ class CompositeAction(Action):
             step.run()
             output_lines.append(f"[{step.name}] {step.output.decode(errors='ignore').strip()}")
             if step.return_code != 0:
-                self._output = "\n".join(output_lines).encode()
+                self.output = "\n".join(output_lines)
                 return step.return_code
-        self._output = "\n".join(output_lines).encode()
+        self.output = "\n".join(output_lines)
         return 0

--- a/kuristo/actions/process_action.py
+++ b/kuristo/actions/process_action.py
@@ -64,7 +64,7 @@ class ProcessAction(Action):
                 self.context.vars["steps"][self.id] = {
                     "output": self._stdout.decode()
                 }
-            self._output = self._stdout
+            self.output = self._stdout
             return self._process.returncode
 
         except subprocess.TimeoutExpired:

--- a/kuristo/actions/regex_base.py
+++ b/kuristo/actions/regex_base.py
@@ -10,7 +10,6 @@ class RegexBaseAction(Action):
         super().__init__(name, context, **kwargs)
         self._target_step = kwargs.get("input")
         self._pattern = pattern
-        self._output = ""
 
     def run(self) -> int:
         output = self._resolve_output()
@@ -20,7 +19,6 @@ class RegexBaseAction(Action):
         else:
             self.on_failure()
             exit_code = -1
-        self._output = self._output.encode()
         return exit_code
 
     def _resolve_output(self):

--- a/kuristo/job.py
+++ b/kuristo/job.py
@@ -287,7 +287,7 @@ class Job:
             self.on_step_finish(self, step)
             self._load_env()
 
-            log_data = step.output.decode()
+            log_data = step.output
             for line in log_data.splitlines():
                 self._logger.log(line)
 


### PR DESCRIPTION
Now, actions have:
- `output` property which holds their output
- this is what can be access via ${{ steps.<id>.output }}
- this was sometimes stored in stdout, which was not used
- `ProcessAction` has `stdout` which becomes action output,
  and `stderr` which is currerntly unused
