### PR TITLE
MPI action can be used as is

### DIFF
--- a/kuristo/actions/mpi_action.py
+++ b/kuristo/actions/mpi_action.py
@@ -1,12 +1,14 @@
+from kuristo.registry import action
 from kuristo.actions.process_action import ProcessAction
 from kuristo.context import Context
+from kuristo.utils import interpolate_str
 import kuristo.config as config
-from abc import abstractmethod
 
 
+@action("core/mpi-run")
 class MPIAction(ProcessAction):
     """
-    Base class for running MPI commands
+    Class for running MPI commands
     """
 
     def __init__(self, name, context: Context, **kwargs) -> None:
@@ -15,19 +17,20 @@ class MPIAction(ProcessAction):
             context=context,
             **kwargs,
         )
+        self._commands = kwargs.get("run", "")
         self._n_ranks = kwargs.get("num-procs", 1)
 
     @property
     def num_cores(self):
         return self._n_ranks
 
-    @abstractmethod
     def create_sub_command(self) -> str:
-        """
-        Subclasses must override this method to return the shell command that will be
-        executed by the MPI launcher
-        """
-        pass
+        assert self.context is not None
+        cmds = interpolate_str(
+            self._commands,
+            self.context.vars
+        )
+        return cmds
 
     def create_command(self):
         cfg = config.get()

--- a/tests/test_mpi_action.py
+++ b/tests/test_mpi_action.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import patch, MagicMock
 from kuristo.actions.mpi_action import MPIAction
 from kuristo.context import Context
@@ -35,9 +34,3 @@ def test_create_command_uses_config_and_sub_command(mock_get):
 
     assert result == "mpirun -np 4 my_mpi_program"
     mock_get.assert_called_once()
-
-
-def test_cannot_instantiate_abstract_mpi_action():
-    ctx = make_context()
-    with pytest.raises(TypeError):
-        MPIAction(name="mpi_test", context=ctx)  # no sub_command implementation


### PR DESCRIPTION
Apps can just use the mpi action to run stuff, no need to build an
application-specific one.  It is not mostly needed, we just need
to be able to do `mpirun -np <n> <command>`
