### PR TITLE
Fixing exit code reported by exodiff checker on success

### DIFF
--- a/kuristo/actions/checks_exodiff.py
+++ b/kuristo/actions/checks_exodiff.py
@@ -95,4 +95,4 @@ class ExodiffCheck(ProcessAction):
                 # Allow diffs (dev mode), override return code
                 return 0
         else:
-            return -1
+            return 0


### PR DESCRIPTION
The exit code was overwritten to -1 when the checker was supposed to report 0.