### PR TITLE
Adding `working-directory` to job

### DIFF
--- a/kuristo/action_factory.py
+++ b/kuristo/action_factory.py
@@ -11,12 +11,20 @@ class ActionFactory:
 
     @staticmethod
     def create(step, context):
+        working_directory = None
+        if context.defaults:
+            if context.defaults.run:
+                if context.defaults.run.working_directory:
+                    working_directory = context.defaults.run.working_directory
+        if step.working_directory:
+            working_directory = step.working_directory
+
         if step.uses is None:
             return ShellAction(
                 step.name,
                 context,
                 id=step.id,
-                working_dir=step.working_directory,
+                working_dir=working_directory,
                 timeout_minutes=step.timeout_minutes,
                 continue_on_error=step.continue_on_error,
                 commands=step.run,
@@ -29,7 +37,7 @@ class ActionFactory:
                 step.name,
                 context,
                 id=step.id,
-                working_dir=step.working_directory,
+                working_dir=working_directory,
                 timeout_minutes=step.timeout_minutes,
                 continue_on_error=step.continue_on_error,
                 **step.params

--- a/kuristo/cli/_batch.py
+++ b/kuristo/cli/_batch.py
@@ -62,7 +62,10 @@ def create_script_params(
         if sp.skip:
             pass
         else:
-            context = Context(base_env=None)
+            context = Context(
+                base_env=None,
+                defaults=sp.defaults
+            )
             actions = build_actions(sp, context)
             n_cores = max(n_cores, required_cores(actions))
             max_time += sp.timeout_minutes

--- a/kuristo/context.py
+++ b/kuristo/context.py
@@ -6,8 +6,9 @@ class Context:
     Context that "tags along" when excuting steps
     """
 
-    def __init__(self, base_env=None, matrix=None):
+    def __init__(self, base_env=None, defaults=None, matrix=None):
         self.env = Env(base_env)
+        self.defaults = defaults
         # variables for substitution
         self.vars = {
             "matrix": matrix,

--- a/kuristo/job.py
+++ b/kuristo/job.py
@@ -100,6 +100,7 @@ class Job:
         self._skipped = False
         self._context = Context(
             base_env=self._get_base_env(),
+            defaults=job_spec.defaults,
             matrix=matrix
         )
         self._context.env.update((var, str(val)) for var, val in job_spec.env.items())

--- a/kuristo/job_spec.py
+++ b/kuristo/job_spec.py
@@ -51,6 +51,15 @@ class Strategy(BaseModel):
     matrix: StrategyMatrix
 
 
+class JobDefaultsRun(BaseModel):
+    # Working directory
+    working_directory: Optional[str] = Field(alias='working-directory', default=None)
+
+
+class JobDefaults(BaseModel):
+    run: JobDefaultsRun
+
+
 class Step(BaseModel):
     """
     Data class with description of a job step
@@ -123,6 +132,8 @@ class JobSpec(BaseModel):
     _file_name: str = PrivateAttr()
     # Environment for this job
     env: Optional[dict] = Field(default={})
+    # Defaults
+    defaults: Optional[JobDefaults] = None
 
     @property
     def id(self):

--- a/tests/assets/tests3/ktests.yaml
+++ b/tests/assets/tests3/ktests.yaml
@@ -40,3 +40,14 @@ jobs:
       - name: Step 1
         working-directory: /tmp
         run: "echo $PWD"
+
+  test-job-cwd:
+    defaults:
+      run:
+        shell: bash
+        working-directory: /tmp
+    steps:
+      - name: print step
+        run: |
+          echo $PWD
+          echo $SHELL

--- a/tests/test_cli_batch.py
+++ b/tests/test_cli_batch.py
@@ -73,8 +73,8 @@ def test_create_script_params_basic(mock_config_get, mock_build_actions):
     mock_config_get.return_value = mock_config_instance
 
     # 2 specs: one skipped, one active
-    skipped_spec = SimpleNamespace(skip=True, timeout_minutes=0)
-    active_spec = SimpleNamespace(skip=False, timeout_minutes=30)
+    skipped_spec = SimpleNamespace(skip=True, timeout_minutes=0, defaults=None)
+    active_spec = SimpleNamespace(skip=False, timeout_minutes=30, defaults=None)
 
     # build_actions returns actions with num_cores
     mock_build_actions.return_value = [SimpleNamespace(num_cores=4)]
@@ -123,8 +123,8 @@ def test_create_script_params_accumulates_time_and_max_cores(mock_config_get, mo
 
     workdir = Path("/data")
     specs = [
-        SimpleNamespace(skip=False, timeout_minutes=10),
-        SimpleNamespace(skip=False, timeout_minutes=20),
+        SimpleNamespace(skip=False, timeout_minutes=10, defaults=None),
+        SimpleNamespace(skip=False, timeout_minutes=20, defaults=None),
     ]
     # First spec -> 2 cores, second -> 8 cores
     mock_build_actions.side_effect = [

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,10 +41,10 @@ def test_failed():
     )
 
     assert result.returncode == 1
-    assert "Success: 3" in result.stdout
+    assert "Success: 4" in result.stdout
     assert "Failed: 1" in result.stdout
     assert "Skipped: 0" in result.stdout
-    assert "Total: 4" in result.stdout
+    assert "Total: 5" in result.stdout
 
 
 def test_user_defined():


### PR DESCRIPTION
We can specify `working-directory` for a job "globally", so we don't have to specify it for each individual step.