### PR TITLE
Fixing printing of log lines in `show` command

### DIFF
--- a/kuristo/cli/_show.py
+++ b/kuristo/cli/_show.py
@@ -15,7 +15,7 @@ def parse_log_line(line):
         timestamp = datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S,%f")
     except ValueError:
         return None
-    return timestamp, tag.strip(), msg.strip()
+    return timestamp, tag.strip(), msg
 
 
 def parse_sections(lines):


### PR DESCRIPTION
- when loading lines from log, the white-space charatres were removed
- this destroyed any indentation created by the run (which is important)