### PR TITLE
Enhance h5diff to support comparing multiple datasets

### DIFF
--- a/docs/actions/h5diff.rst
+++ b/docs/actions/h5diff.rst
@@ -1,12 +1,12 @@
 checks/h5diff
 =============
 
-The ``h5diff`` action compares two HDF5 files (`.h5`) to verify that simulation results
-match a known reference.
+The ``h5diff`` action compares HDF5 files (`.h5`) to verify that simulation results
+match a known reference. You can compare entire files or specific datasets within files.
 
 
-Example Usage
--------------
+Example Usage - Compare Entire Files
+-------------------------------------
 
 .. code-block:: yaml
 
@@ -18,8 +18,29 @@ Example Usage
          rel-tol: 1e-6
 
 
-Arguments
----------
+Example Usage - Compare Multiple Datasets
+------------------------------------------
+
+Compare specific datasets within the HDF5 files, each with its own tolerance:
+
+.. code-block:: yaml
+
+   steps:
+     - uses: checks/h5diff
+       with:
+         gold: ref.h5
+         test: result.h5
+         datasets:
+           - path: /pressure
+             rel-tol: 1e-6
+           - path: /velocity
+             abs-tol: 0.001
+           - path: /temperature
+             rel-tol: 1e-5
+
+
+Arguments - File Comparison
+---------------------------
 
 ``gold`` (string, required)
    Path to the reference HDF5 file.
@@ -28,17 +49,44 @@ Arguments
    Path to the output HDF5 file to compare.
 
 ``abs-tol`` (float, optional)
-   Absolute difference threshold.
+   Absolute difference threshold. Used when comparing entire files.
 
 ``rel-tol`` (float, optional)
-   Relative difference threshold.
+   Relative difference threshold. Used when comparing entire files.
 
+
+Arguments - Dataset Comparison
+------------------------------
+
+``gold`` (string, required)
+   Path to the reference HDF5 file.
+
+``test`` (string, required)
+   Path to the output HDF5 file to compare.
+
+``datasets`` (list, optional)
+   List of datasets to compare. Each dataset is a dictionary with:
+
+   - ``path`` (string, required): Path to the dataset (e.g., ``/pressure``, ``/data/velocity``)
+   - ``rel-tol`` (float, optional): Relative tolerance for this dataset
+   - ``abs-tol`` (float, optional): Absolute tolerance for this dataset
+
+   Either ``rel-tol`` or ``abs-tol`` must be provided for each dataset.
+
+
+Optional Arguments
+------------------
+
+``fail-on-diff`` (boolean, optional, default: true)
+   If ``false``, differences found by h5diff will not cause the step to fail.
+   Useful for development and debugging.
 
 
 .. admonition:: Notes
 
-   - Either ``abs-tol`` or ``rel-tol`` must be provided
+   - Either ``abs-tol`` or ``rel-tol`` must be provided (for entire file comparison) or for each dataset
    - Uses ``h5diff`` from HDF5 distribution. Make sure it is on your PATH when running kuristo.
+   - When comparing multiple datasets, the step fails if any dataset comparison fails (unless ``fail-on-diff`` is false)
 
 
 .. seealso::

--- a/kuristo/actions/checks_h5diff.py
+++ b/kuristo/actions/checks_h5diff.py
@@ -1,4 +1,6 @@
 import shlex
+import subprocess
+import os
 from kuristo.registry import action
 from kuristo.actions.process_action import ProcessAction
 from kuristo.context import Context
@@ -7,28 +9,77 @@ from kuristo.context import Context
 @action("checks/h5diff")
 class H5DiffCheck(ProcessAction):
     """
-    Run h5diff on two HDF5 files.
+    Run h5diff on two HDF5 files, optionally comparing specific datasets.
 
     Parameters:
         gold (str): Path to gold/reference file
         test (str): Path to test output file
-        rel-tol (float): Relative tolerance
-        abs-tol (float): Absolute tolerance
+        rel-tol (float): Relative tolerance (used if no datasets specified)
+        abs-tol (float): Absolute tolerance (used if no datasets specified)
         fail-on-diff (bool): If false, ignore diff return code
+        datasets (list, optional): List of datasets to compare with individual tolerances.
+                                 Each item is a dict with 'path', and optionally 'rel-tol'/'abs-tol'
     """
 
     def __init__(self, name, context: Context, **kwargs):
         super().__init__(name, context, **kwargs)
         self._gold_path = kwargs["gold"]
         self._test_path = kwargs["test"]
-        # "global" tolerances
-        self._rel_tol = kwargs.get("rel-tol", None)
-        self._abs_tol = kwargs.get("abs-tol", None)
         self._fail_on_diff = kwargs.get("fail-on-diff", True)
-        if self._rel_tol is None and self._abs_tol is None:
-            raise RuntimeError("h5diff: Must provide either `rel-tol` or `abs-tol`")
+
+        # Check if comparing specific datasets or entire files
+        self._datasets = kwargs.get("datasets", None)
+
+        if self._datasets:
+            # Multiple datasets mode - validate each dataset
+            if not isinstance(self._datasets, list):
+                raise RuntimeError("h5diff: `datasets` must be a list")
+            self._validate_datasets()
+        else:
+            # Single file comparison mode (backward compatible)
+            self._rel_tol = kwargs.get("rel-tol", None)
+            self._abs_tol = kwargs.get("abs-tol", None)
+            if self._rel_tol is None and self._abs_tol is None:
+                raise RuntimeError("h5diff: Must provide either `rel-tol` or `abs-tol`")
+
+    def _validate_datasets(self):
+        """Validate that each dataset has required tolerance"""
+        for i, dataset in enumerate(self._datasets):
+            if not isinstance(dataset, dict):
+                raise RuntimeError(f"h5diff: dataset[{i}] must be a dictionary with 'path' and tolerance")
+            if "path" not in dataset:
+                raise RuntimeError(f"h5diff: dataset[{i}] must have a 'path' field")
+            rel_tol = dataset.get("rel-tol", None)
+            abs_tol = dataset.get("abs-tol", None)
+            if rel_tol is None and abs_tol is None:
+                raise RuntimeError(f"h5diff: dataset[{i}] ({dataset['path']}) must provide either `rel-tol` or `abs-tol`")
+
+    def _create_command_for_dataset(self, dataset: dict) -> str:
+        """Create h5diff command for a single dataset"""
+        cmd = ["h5diff"]
+        cmd += ["-r"]
+
+        abs_tol = dataset.get("abs-tol", None)
+        rel_tol = dataset.get("rel-tol", None)
+
+        if abs_tol is not None:
+            cmd += [f"--delta={abs_tol}"]
+        elif rel_tol is not None:
+            cmd += [f"--relative={rel_tol}"]
+
+        cmd += [self._gold_path]
+        cmd += [self._test_path]
+        cmd += [dataset["path"]]
+
+        return shlex.join(cmd)
 
     def create_command(self):
+        """Create command for backward compatibility (single file comparison)"""
+        if self._datasets:
+            # For multiple datasets, we can't return a single command
+            # This is handled in run() instead
+            return ""
+
         cmd = ["h5diff"]
         cmd += ["-r"]
         if self._abs_tol is not None:
@@ -40,15 +91,78 @@ class H5DiffCheck(ProcessAction):
         return shlex.join(cmd)
 
     def run(self) -> int:
+        """Run h5diff comparison(s)"""
+        if self._datasets:
+            # Multiple datasets mode
+            return self._run_multiple_datasets()
+        else:
+            # Single file comparison mode (backward compatible)
+            return self._run_single_file()
+
+    def _run_single_file(self) -> int:
+        """Run comparison of entire files (original behavior)"""
         exit_code = super().run()
 
         # interpret return code
         if exit_code != 0:
             if self._fail_on_diff:
-                # Leave return_code as is, fail the test
                 return exit_code
             else:
                 # Allow diffs (dev mode), override return code
                 return 0
+        else:
+            return 0
+
+    def _run_multiple_datasets(self) -> int:
+        """Run h5diff for each dataset and aggregate results"""
+        timeout = self.timeout_minutes
+        env = os.environ.copy()
+        if self.context is not None:
+            env.update(self.context.env)
+        env.update((var, str(val)) for var, val in self._env.items())
+
+        all_passed = True
+        outputs = []
+
+        for dataset in self._datasets:
+            cmd = self._create_command_for_dataset(dataset)
+            dataset_path = dataset["path"]
+
+            try:
+                process = subprocess.Popen(
+                    cmd,
+                    shell=True,
+                    cwd=self._cwd,
+                    env=env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT
+                )
+
+                stdout, _ = process.communicate(timeout=timeout * 60)
+                output = stdout.decode()
+                outputs.append(f"Dataset {dataset_path}: exit code {process.returncode}\n{output}")
+
+                if process.returncode != 0:
+                    all_passed = False
+
+            except subprocess.TimeoutExpired:
+                process.kill()
+                all_passed = False
+                outputs.append(f"Dataset {dataset_path}: TIMEOUT")
+
+        # Store combined output
+        if self.id is not None:
+            combined_output = "\n".join(outputs)
+            self.context.vars["steps"][self.id] = {
+                "output": combined_output
+            }
+
+        self.output = "\n".join(outputs).encode()
+
+        # Return appropriate exit code
+        if all_passed:
+            return 0
+        elif self._fail_on_diff:
+            return 1
         else:
             return 0

--- a/tests/test_checks_h5diff.py
+++ b/tests/test_checks_h5diff.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from kuristo.context import Context
 from kuristo.actions import H5DiffCheck
 
@@ -8,9 +8,11 @@ from kuristo.actions import H5DiffCheck
 def dummy_context():
     ctx = MagicMock(spec=Context)
     ctx.env = {}
-    ctx.vars = {}
+    ctx.vars = {"steps": {}}
     return ctx
 
+
+# ===== BACKWARD COMPATIBILITY TESTS (Single file comparison) =====
 
 def test_create_command_with_abs_tol(dummy_context):
     check = H5DiffCheck(
@@ -92,3 +94,130 @@ def test_run_success(dummy_context):
     )
     check.run_command = MagicMock(return_value=0)
     assert check
+
+
+# ===== MULTIPLE DATASETS TESTS =====
+
+def test_datasets_requires_path(dummy_context):
+    """Dataset must have 'path' field"""
+    with pytest.raises(RuntimeError, match="must have a 'path' field"):
+        H5DiffCheck(
+            name="test",
+            context=dummy_context,
+            gold="gold.h5",
+            test="test.h5",
+            datasets=[
+                {"rel-tol": 1e-6}  # missing 'path'
+            ]
+        )
+
+
+def test_datasets_requires_tolerance(dummy_context):
+    """Each dataset must have rel-tol or abs-tol"""
+    with pytest.raises(RuntimeError, match="must provide either `rel-tol` or `abs-tol`"):
+        H5DiffCheck(
+            name="test",
+            context=dummy_context,
+            gold="gold.h5",
+            test="test.h5",
+            datasets=[
+                {"path": "/pressure"}  # missing tolerance
+            ]
+        )
+
+
+def test_create_command_for_dataset(dummy_context):
+    """Test command creation for individual dataset"""
+    check = H5DiffCheck(
+        name="test",
+        context=dummy_context,
+        gold="gold.h5",
+        test="test.h5",
+        datasets=[
+            {"path": "/pressure", "rel-tol": 1e-6}
+        ]
+    )
+    cmd = check._create_command_for_dataset({"path": "/pressure", "rel-tol": 1e-6})
+    assert "h5diff" in cmd
+    assert "--relative=1e-06" in cmd
+    assert "/pressure" in cmd
+    assert "gold.h5" in cmd
+    assert "test.h5" in cmd
+
+
+def test_multiple_datasets_all_pass(dummy_context):
+    """All dataset comparisons pass"""
+    check = H5DiffCheck(
+        name="test",
+        context=dummy_context,
+        gold="gold.h5",
+        test="test.h5",
+        datasets=[
+            {"path": "/pressure", "rel-tol": 1e-6},
+            {"path": "/velocity", "abs-tol": 0.001},
+            {"path": "/temperature", "rel-tol": 1e-5}
+        ]
+    )
+
+    mock_popen = MagicMock()
+    mock_popen.communicate.return_value = (b"No differences found", None)
+    mock_popen.returncode = 0
+
+    with patch("subprocess.Popen", return_value=mock_popen):
+        assert check.run() == 0
+
+
+def test_multiple_datasets_one_fails(dummy_context):
+    """One dataset comparison fails, should fail overall"""
+    check = H5DiffCheck(
+        name="test",
+        context=dummy_context,
+        gold="gold.h5",
+        test="test.h5",
+        datasets=[
+            {"path": "/pressure", "rel-tol": 1e-6},
+            {"path": "/velocity", "abs-tol": 0.001}
+        ],
+        **{"fail-on-diff": True}
+    )
+
+    # First call succeeds, second fails
+    mock_popen = MagicMock()
+    mock_popen.communicate.return_value = (b"", None)
+    mock_popen.returncode = 1
+
+    with patch("subprocess.Popen", return_value=mock_popen):
+        assert check.run() == 1
+
+
+def test_multiple_datasets_fail_on_diff_false(dummy_context):
+    """Multiple datasets fail but fail-on-diff is false"""
+    check = H5DiffCheck(
+        name="test",
+        context=dummy_context,
+        gold="gold.h5",
+        test="test.h5",
+        datasets=[
+            {"path": "/pressure", "rel-tol": 1e-6}
+        ],
+        **{"fail-on-diff": False}
+    )
+
+    mock_popen = MagicMock()
+    mock_popen.communicate.return_value = (b"Differences found", None)
+    mock_popen.returncode = 1
+
+    with patch("subprocess.Popen", return_value=mock_popen):
+        assert check.run() == 0
+
+
+def test_datasets_must_be_list(dummy_context):
+    """datasets parameter must be a list"""
+    with pytest.raises(RuntimeError, match="`datasets` must be a list"):
+        H5DiffCheck(
+            name="test",
+            context=dummy_context,
+            gold="gold.h5",
+            test="test.h5",
+            datasets={"path": "/pressure", "rel-tol": 1e-6}  # not a list
+        )


### PR DESCRIPTION
Allow users to compare specific datasets within HDF5 files, each with individual tolerances, without creating multiple h5diff steps.

Features:
- New optional 'datasets' parameter for comparing specific datasets
- Each dataset can have its own rel-tol and/or abs-tol
- Fully backward compatible - existing syntax still works
- Step fails if any dataset comparison fails
- Optional fail-on-diff flag respected for dataset mode

Implementation:
- Refactored H5DiffCheck to support two modes:
  - Single file mode (backward compatible): Compare entire files
  - Multiple dataset mode: Compare specific datasets with per-dataset tolerances
- Added _run_multiple_datasets() to execute h5diff for each dataset
- Aggregates results - fails if any comparison fails

Testing:
- Added 7 new tests for dataset comparison functionality
- All 13 existing tests still pass
- Tests cover: validation, command generation, multiple datasets, failure scenarios

Documentation:
- Added example for comparing multiple datasets
- Documented new 'datasets' parameter with its structure
- Clarified tolerances for both modes
- Added notes about behavior with multiple datasets

Closes #79 