### PR TITLE
Add tag resolution to `--run-id` arguments

### DIFF
--- a/kuristo/cli/_report.py
+++ b/kuristo/cli/_report.py
@@ -56,6 +56,7 @@ def report(args):
     cfg = config.get()
 
     run_name = args.run_id or "latest"
+    run_name = utils.resolve_run_id(cfg.log_dir, run_name)
     runs_dir = cfg.log_dir / "runs" / run_name
     report_path = Path(runs_dir / "report.yaml")
     if not report_path.exists():

--- a/kuristo/cli/_show.py
+++ b/kuristo/cli/_show.py
@@ -184,6 +184,7 @@ def display_job_log(log_path: Path, filters=None):
 def show(args):
     cfg = config.get()
     run_name = args.run_id or "latest"
+    run_name = utils.resolve_run_id(cfg.log_dir, run_name)
     runs_dir = cfg.log_dir / "runs" / run_name
 
     log_path = Path(runs_dir / f"job-{args.job}.log")

--- a/kuristo/cli/_status.py
+++ b/kuristo/cli/_status.py
@@ -61,6 +61,7 @@ def print_report(report, filters: list):
 def status(args):
     cfg = config.get()
     run_name = args.run_id or "latest"
+    run_name = utils.resolve_run_id(cfg.log_dir, run_name)
     runs_dir = cfg.log_dir / "runs" / run_name
     report_path = runs_dir / "report.yaml"
     if not report_path.exists():

--- a/kuristo/utils.py
+++ b/kuristo/utils.py
@@ -185,6 +185,28 @@ def is_run_tagged(log_dir: Path, run_id: str) -> bool:
     return len(get_tags_for_run(log_dir, run_id)) > 0
 
 
+def resolve_run_id(log_dir: Path, run_id: str) -> str:
+    """
+    Resolve a run ID (which may be an alias like a tag) to the actual run ID.
+    If run_id is a tag, follows the symlink to get the actual run ID.
+    Otherwise returns run_id unchanged.
+    """
+    tags_dir = log_dir / "tags"
+    tag_path = tags_dir / run_id
+
+    # Check if it's a tag
+    if tag_path.is_symlink():
+        try:
+            target = tag_path.resolve()
+            return target.name
+        except Exception:
+            # If symlink is broken, return the original input
+            return run_id
+
+    # Not a tag, return as-is
+    return run_id
+
+
 def interpolate_str(text: str, variables: dict) -> str:
     normalized = text.replace("${{", "{{")
     template = Template(normalized)


### PR DESCRIPTION
Allow tags to be used as aliases for run IDs in `status`, `show`, `report`, and `tag` commands.

Introduces `resolve_run_id()` function that checks if a provided `run_id` is a tag and resolves it to the actual run ID.