### PR TITLE
Fixing return code in check convergence rate action

### DIFF
--- a/kuristo/actions/checks_convergence_rate.py
+++ b/kuristo/actions/checks_convergence_rate.py
@@ -80,4 +80,4 @@ class ConvergenceRateCheck(Action):
                 return -1
         except FileNotFoundError:
             self.output = f"Failed to open {self._input_file}"
-            return 0
+            return -2


### PR DESCRIPTION
When file is not found, the action must fail (i.e. return non-zero code)