### PR TITLE
Jobs are numbered consecutively

### DIFF
--- a/kuristo/job.py
+++ b/kuristo/job.py
@@ -441,9 +441,7 @@ class JobJoiner:
         @param event Signalling event when job status changes
         @param job_spec Job specification
         """
-        Job.ID = Job.ID + 1
         self._event = event
-        self._num = Job.ID
         self._id = id
         self._name = id
         self._spec = spec
@@ -470,13 +468,6 @@ class JobJoiner:
         Return job name
         """
         return self._name
-
-    @property
-    def num(self):
-        """
-        Return job number
-        """
-        return self._num
 
     @property
     def is_skipped(self):

--- a/kuristo/scheduler.py
+++ b/kuristo/scheduler.py
@@ -207,6 +207,8 @@ class Scheduler:
                         ui.status_line(job, "STARTING", self._max_id_width, self._max_label_len)
 
     def _job_completed(self, job):
+        assert isinstance(job, Job)
+
         with self._lock:
             if job.return_code == 0:
                 ui.status_line(job, "PASS", self._max_id_width, self._max_label_len)
@@ -272,6 +274,8 @@ class Scheduler:
         self._progress.update(step_task_id, visible=True)
 
     def _on_step_finish(self, job, step):
+        assert isinstance(job, Job)
+
         step_task_id = job.step_task_id(step)
         self._progress.remove_task(step_task_id)
 


### PR DESCRIPTION
- `JobJoiner` does not get a number, becuase it does not really need it
- This makes "true" jobs numbered consecutively
- Less user confusion about "non-existing job", since they do not see an expected number

Closes #109 