### PR TITLE
Adding a switch to rerun jobs that failed in a previous run

### DIFF
--- a/extras/completions/_kuristo
+++ b/extras/completions/_kuristo
@@ -38,6 +38,7 @@ case $state in
           '--help[Show help message and exit]' \
           '--verbose[Verbose level]:int' \
           '*--label[Filter jobs by label \(can be specified multiple times\)]:label' \
+          '--rerun-failed[Re-run only jobs that failed in the last run \(includes their dependencies\)]' \
           '*:Locations to scan:_files'
         ;;
       doctor)

--- a/kuristo/cli/__init__.py
+++ b/kuristo/cli/__init__.py
@@ -54,6 +54,11 @@ def build_parser():
         metavar="LABEL",
         help="Filter jobs by label (can be specified multiple times)",
     )
+    run_parser.add_argument(
+        "--rerun-failed",
+        action="store_true",
+        help="Re-run only jobs that failed in the last run (includes their dependencies)",
+    )
     run_parser.add_argument("locations", nargs="*", help="Locations to scan for workflow files")
 
     # Doctor command

--- a/kuristo/cli/_run.py
+++ b/kuristo/cli/_run.py
@@ -4,12 +4,28 @@ import yaml
 
 import kuristo.config as config
 import kuristo.utils as utils
+from kuristo.exceptions import UserException
 from kuristo.job import Job
 from kuristo.plugin_loader import load_user_steps_from_kuristo_dir
 from kuristo.resources import Resources
 from kuristo.scanner import scan_locations
 from kuristo.scheduler import Scheduler
 from kuristo.workflow import parse_workflow_files
+
+
+def _get_failed_job_names(log_dir):
+    """
+    Read the latest run's report and return a set of failed job names.
+    Raises UserException if no previous run exists or no jobs failed.
+    """
+    report_path = log_dir / "runs" / "latest" / "report.yaml"
+    if not report_path.exists():
+        raise UserException("No previous run found. Cannot use --rerun-failed.")
+    report = utils.read_report(report_path)
+    failed = {r["job-name"] for r in report.get("results", []) if r.get("status") == "failed"}
+    if not failed:
+        raise UserException("No failed jobs found in the last run.")
+    return failed
 
 
 def create_results(jobs):
@@ -54,6 +70,12 @@ def run_jobs(args):
 
     cfg = config.get()
     out_dir = utils.create_run_output_dir(cfg.log_dir)
+
+    # Get failed job names before updating the "latest" symlink
+    failed_job_names = None
+    if args.rerun_failed:
+        failed_job_names = _get_failed_job_names(cfg.log_dir)
+
     utils.prune_old_runs(cfg.log_dir, cfg.log_history)
     utils.update_latest_symlink(cfg.log_dir, out_dir)
 
@@ -63,7 +85,7 @@ def run_jobs(args):
     workflows = parse_workflow_files(workflow_files)
 
     rcs = Resources()
-    scheduler = Scheduler(workflows, rcs, out_dir, labels=args.labels)
+    scheduler = Scheduler(workflows, rcs, out_dir, labels=args.labels, job_names=failed_job_names)
     scheduler.check()
     scheduler.run_all_jobs()
 

--- a/kuristo/job.py
+++ b/kuristo/job.py
@@ -463,6 +463,13 @@ class JobJoiner:
         return self._id
 
     @property
+    def num(self):
+        """
+        Return job number
+        """
+        return None
+
+    @property
     def name(self):
         """
         Return job name

--- a/kuristo/scheduler.py
+++ b/kuristo/scheduler.py
@@ -95,10 +95,10 @@ class Scheduler:
             self._graph = self._apply_name_filter(self._graph, job_names)
 
         self._max_label_len = cfg.console_width
+        self._max_num_width = 1
         for job in self._graph.nodes:
             self._max_label_len = max(self._max_label_len, len(job.name) + 1)
-
-        self._max_id_width = len(str(self._graph.number_of_nodes()))
+            self._max_num_width = max(self._max_num_width, len(str(job.num)))
 
         self._resources = rcs
         if cfg.no_ansi:
@@ -273,7 +273,7 @@ class Scheduler:
             for job in ready_jobs:
                 if job.is_skipped:
                     job.skip_process()
-                    ui.status_line(job, "SKIP", self._max_id_width, self._max_label_len)
+                    ui.status_line(job, "SKIP", self._max_num_width, self._max_label_len)
                     self._n_skipped = self._n_skipped + 1
                     continue
 
@@ -292,20 +292,20 @@ class Scheduler:
                         self._tasks[job.num] = task_id
                         job.create_step_tasks(self._progress)
                         job.start()
-                        ui.status_line(job, "STARTING", self._max_id_width, self._max_label_len)
+                        ui.status_line(job, "STARTING", self._max_num_width, self._max_label_len)
 
     def _job_completed(self, job):
         assert isinstance(job, Job)
 
         with self._lock:
             if job.return_code == 0:
-                ui.status_line(job, "PASS", self._max_id_width, self._max_label_len)
+                ui.status_line(job, "PASS", self._max_num_width, self._max_label_len)
                 self._n_success = self._n_success + 1
             elif job.return_code == 124:
-                ui.status_line(job, "TIMEOUT", self._max_id_width, self._max_label_len)
+                ui.status_line(job, "TIMEOUT", self._max_num_width, self._max_label_len)
                 self._n_failed = self._n_failed + 1
             else:
-                ui.status_line(job, "FAIL", self._max_id_width, self._max_label_len)
+                ui.status_line(job, "FAIL", self._max_num_width, self._max_label_len)
                 self._n_failed = self._n_failed + 1
             task_id = self._tasks[job.num]
             self._progress.remove_task(task_id)

--- a/kuristo/scheduler.py
+++ b/kuristo/scheduler.py
@@ -66,13 +66,19 @@ class Scheduler:
     """
 
     def __init__(
-        self, workflows: list[Workflow], rcs: Resources, out_dir, labels: list[str] | None = None
+        self,
+        workflows: list[Workflow],
+        rcs: Resources,
+        out_dir,
+        labels: list[str] | None = None,
+        job_names: set[str] | None = None,
     ) -> None:
         """
         @param workflows: [Workflows] List of workflows
         @param rcs: Resources Resource to be scheduled
         @param out_dir: Directory where we write logs
         @param labels: Optional list of labels to filter jobs
+        @param job_names: Optional set of job names to run (e.g., from --rerun-failed)
         @param config: Configuration
         @param job_times_path: File name to store timing report into
         """
@@ -85,6 +91,8 @@ class Scheduler:
         self._graph = self._create_graph(workflows)
         if labels:
             self._graph = self._apply_label_filter(self._graph, labels)
+        if job_names:
+            self._graph = self._apply_name_filter(self._graph, job_names)
 
         self._max_label_len = cfg.console_width
         for job in self._graph.nodes:
@@ -213,6 +221,37 @@ class Scheduler:
         for job in graph.nodes:
             if job not in required_jobs:
                 nodes_to_remove.append(job)
+        graph.remove_nodes_from(nodes_to_remove)
+        return graph
+
+    def _apply_name_filter(self, graph: netx.DiGraph, job_names: set[str]) -> netx.DiGraph:
+        """
+        Filter jobs based on job names, including all transitive dependencies.
+        Used for --rerun-failed to re-run failed jobs and their dependencies.
+
+        @param job_names: Set of job names to run (e.g., from previous run's report)
+        """
+        # Find all jobs whose name is in job_names
+        matching_jobs = {job for job in graph.nodes if job.name in job_names}
+
+        # Collect all transitive dependencies of matching jobs
+        required_jobs = set(matching_jobs)
+        to_visit = list(matching_jobs)
+        visited = set()
+
+        while to_visit:
+            current = to_visit.pop(0)
+            if current in visited:
+                continue
+            visited.add(current)
+
+            for predecessor in graph.predecessors(current):
+                if predecessor not in required_jobs:
+                    required_jobs.add(predecessor)
+                    to_visit.append(predecessor)
+
+        # Remove all jobs not in required set
+        nodes_to_remove = [job for job in graph.nodes if job not in required_jobs]
         graph.remove_nodes_from(nodes_to_remove)
         return graph
 

--- a/tests/test_rerun_failed.py
+++ b/tests/test_rerun_failed.py
@@ -1,0 +1,61 @@
+import subprocess
+import tempfile
+from pathlib import Path
+
+ASSETS_DIR = Path(__file__).parent / "assets"
+
+
+def test_rerun_failed_basic():
+    """Test that --rerun-failed flag is recognized and can run"""
+    test_dir = ASSETS_DIR / "tests1"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        import os
+
+        env = os.environ.copy()
+        env["KURISTO_LOG_DIR"] = tmpdir
+
+        # First run - should succeed
+        result = subprocess.run(
+            ["kuristo", "--no-ansi", "run", str(test_dir)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "Success: 2" in result.stdout
+
+        # Second run with --rerun-failed - should fail because no jobs failed
+        result = subprocess.run(
+            ["kuristo", "--no-ansi", "run", "--rerun-failed", str(test_dir)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 1
+        assert "No failed jobs found" in result.stdout
+
+
+def test_rerun_failed_with_actual_failures():
+    """Test that --rerun-failed correctly identifies and re-runs failed jobs"""
+    test_dir = ASSETS_DIR / "tests3"
+
+    # First run - will have failures
+    result = subprocess.run(
+        ["kuristo", "--no-ansi", "run", str(test_dir)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "Failed: 1" in result.stdout
+
+    # Second run with --rerun-failed - should detect the failed job
+    # Since the test is designed to always fail, this will fail again
+    result = subprocess.run(
+        ["kuristo", "--no-ansi", "run", "--rerun-failed", str(test_dir)],
+        capture_output=True,
+        text=True,
+    )
+    # The important thing is that it ran and detected the failed job from the previous run
+    # It will fail again because the job is designed to fail
+    assert "Failed: 1" in result.stdout or "test-that-fails" in result.stdout


### PR DESCRIPTION
User now can do:
```
kuristo run --rerun-failed
```
to rerun jobs that failed in a previous run

Closes #112