### PR TITLE
Interpolate all action parameters

### DIFF
--- a/kuristo/action_factory.py
+++ b/kuristo/action_factory.py
@@ -1,6 +1,7 @@
 from kuristo.actions.shell_action import ShellAction
 from kuristo.exceptions import UserException
 from kuristo.registry import get_action
+from kuristo.utils import interpolate_value
 
 
 class ActionFactory:
@@ -21,6 +22,9 @@ class ActionFactory:
             working_directory = step.working_directory
 
         if step.uses is None:
+            commands = step.run
+            if context is not None:
+                commands = interpolate_value(commands, context.vars)
             return ShellAction(
                 step.name,
                 context,
@@ -28,12 +32,15 @@ class ActionFactory:
                 working_dir=working_directory,
                 timeout_minutes=step.timeout_minutes,
                 continue_on_error=step.continue_on_error,
-                commands=step.run,
+                commands=commands,
                 num_cores=step.num_cores,
                 env=step.env,
             )
         elif get_action(step.uses):
             cls = get_action(step.uses)
+            params = step.params
+            if context is not None:
+                params = interpolate_value(params, context.vars)
             return cls(
                 step.name,
                 context,
@@ -41,7 +48,7 @@ class ActionFactory:
                 working_dir=working_directory,
                 timeout_minutes=step.timeout_minutes,
                 continue_on_error=step.continue_on_error,
-                **step.params,
+                **params,
             )
         else:
             raise UserException(f"Requested unknown action: {step.uses}")

--- a/kuristo/actions/mpi_action.py
+++ b/kuristo/actions/mpi_action.py
@@ -2,7 +2,6 @@ import kuristo.config as config
 from kuristo.actions.process_action import ProcessAction
 from kuristo.context import Context
 from kuristo.registry import action
-from kuristo.utils import interpolate_str
 
 
 @action("core/mpi-run")
@@ -25,11 +24,7 @@ class MPIAction(ProcessAction):
         return self._n_ranks
 
     def create_sub_command(self) -> str:
-        if self.context is None:
-            cmds = self._commands
-        else:
-            cmds = interpolate_str(self._commands, self.context.vars)
-        return cmds
+        return self._commands
 
     def create_command(self):
         cfg = config.get()

--- a/kuristo/actions/shell_action.py
+++ b/kuristo/actions/shell_action.py
@@ -1,6 +1,5 @@
 from kuristo.actions.process_action import ProcessAction
 from kuristo.context import Context
-from kuristo.utils import interpolate_str
 
 
 class ShellAction(ProcessAction):
@@ -14,11 +13,7 @@ class ShellAction(ProcessAction):
         self._n_cores = kwargs.get("num_cores", 1)
 
     def create_command(self):
-        if self.context is None:
-            cmds = self._commands
-        else:
-            cmds = interpolate_str(self._commands, self.context.vars)
-        return cmds
+        return self._commands
 
     @property
     def num_cores(self):

--- a/kuristo/utils.py
+++ b/kuristo/utils.py
@@ -208,6 +208,28 @@ def interpolate_str(text: str, variables: dict) -> str:
     return template.render(**variables)
 
 
+def interpolate_value(value, variables: dict):
+    """
+    Recursively interpolate variables in any value type.
+
+    Supports strings (using Jinja2), lists, and dicts.
+    Other types are returned unchanged.
+    If a variable is undefined, it is replaced with an empty string
+    """
+    if isinstance(value, str):
+        try:
+            return interpolate_str(value, variables)
+        except Exception:
+            # If interpolation fails (undefined variables, etc.), return original
+            return value
+    elif isinstance(value, list):
+        return [interpolate_value(item, variables) for item in value]
+    elif isinstance(value, dict):
+        return {key: interpolate_value(val, variables) for key, val in value.items()}
+    else:
+        return value
+
+
 def minutes_to_hhmmss(minutes: int) -> str:
     """
     Convert minutes into "H:MM:SS"

--- a/tests/test_action_interpolation.py
+++ b/tests/test_action_interpolation.py
@@ -1,0 +1,251 @@
+import pytest
+
+from kuristo.actions.action import Action
+from kuristo.context import Context
+from kuristo.utils import interpolate_value
+
+
+class DummyAction(Action):
+    """Minimal concrete Action subclass for testing"""
+
+    def run(self) -> int:
+        return 0
+
+
+def create_action_with_interpolation(action_class, name, context, **kwargs):
+    """
+    Create an action with parameter interpolation (simulating ActionFactory behavior).
+    """
+    if context is not None:
+        kwargs = interpolate_value(kwargs, context.vars)
+    return action_class(name, context, **kwargs)
+
+
+class TestInterpolateUserKwargs:
+    """Test parameter interpolation in Action base class"""
+
+    @pytest.fixture
+    def context_with_vars(self):
+        ctx = Context()
+        ctx.vars = {
+            "matrix": {"item": "test_value"},
+            "steps": {"prev_step": {"output": "previous_output"}},
+        }
+        return ctx
+
+    def test_interpolate_string_parameter(self, context_with_vars):
+        """Test interpolation of string parameters"""
+        action = DummyAction(
+            "test",
+            context_with_vars,
+            id="step1",
+            reference="${{ matrix.item }}",
+        )
+        # Verify the kwarg was interpolated
+        assert action.context is not None
+        # We need to check the kwargs were modified, but they're not stored in the action
+        # Let's verify by creating the action and checking if it was called correctly
+
+    def test_interpolate_string_parameter_modified(self, context_with_vars):
+        """Test that string parameters are interpolated by checking kwargs"""
+
+        class TestAction(Action):
+            def __init__(self, name, context, **kwargs):
+                super().__init__(name, context, **kwargs)
+                self.test_param = kwargs.get("reference")
+
+            def run(self) -> int:
+                return 0
+
+        action = create_action_with_interpolation(
+            TestAction,
+            "test",
+            context_with_vars,
+            id="step1",
+            reference="${{ matrix.item }}",
+        )
+        assert action.test_param == "test_value"
+
+    def test_interpolate_list_parameter(self, context_with_vars):
+        """Test interpolation of list parameters with variable expansion"""
+
+        class ListAction(Action):
+            def __init__(self, name, context, **kwargs):
+                super().__init__(name, context, **kwargs)
+                self.items = kwargs.get("items")
+
+            def run(self) -> int:
+                return 0
+
+        action = create_action_with_interpolation(
+            ListAction,
+            "test",
+            context_with_vars,
+            id="step1",
+            items=[
+                "prefix_${{ matrix.item }}_suffix",
+                "plain_string",
+            ],
+        )
+        assert action.items == [
+            "prefix_test_value_suffix",
+            "plain_string",
+        ]
+
+    def test_interpolate_dict_parameter(self, context_with_vars):
+        """Test interpolation of dict parameters"""
+
+        class DictAction(Action):
+            def __init__(self, name, context, **kwargs):
+                super().__init__(name, context, **kwargs)
+                self.config = kwargs.get("config")
+
+            def run(self) -> int:
+                return 0
+
+        action = create_action_with_interpolation(
+            DictAction,
+            "test",
+            context_with_vars,
+            id="step1",
+            config={
+                "gold": "${{ matrix.item }}_gold",
+                "test": "${{ matrix.item }}_test",
+                "plain": "value",
+            },
+        )
+        assert action.config == {
+            "gold": "test_value_gold",
+            "test": "test_value_test",
+            "plain": "value",
+        }
+
+    def test_interpolate_nested_structures(self, context_with_vars):
+        """Test interpolation of nested structures (lists of dicts)"""
+
+        class NestedAction(Action):
+            def __init__(self, name, context, **kwargs):
+                super().__init__(name, context, **kwargs)
+                self.datasets = kwargs.get("datasets")
+
+            def run(self) -> int:
+                return 0
+
+        action = create_action_with_interpolation(
+            NestedAction,
+            "test",
+            context_with_vars,
+            id="step1",
+            datasets=[
+                {
+                    "path": "/data/${{ matrix.item }}/gold.h5",
+                    "rel-tol": 1e-6,
+                },
+                {
+                    "path": "/data/${{ matrix.item }}/test.h5",
+                    "rel-tol": 1e-6,
+                },
+            ],
+        )
+        assert action.datasets == [
+            {
+                "path": "/data/test_value/gold.h5",
+                "rel-tol": 1e-6,
+            },
+            {
+                "path": "/data/test_value/test.h5",
+                "rel-tol": 1e-6,
+            },
+        ]
+
+    def test_no_interpolation_for_framework_kwargs(self, context_with_vars):
+        """Test that framework kwargs are not interpolated"""
+
+        class FrameworkAction(Action):
+            def __init__(self, name, context, **kwargs):
+                super().__init__(name, context, **kwargs)
+                self.stored_working_dir = kwargs.get("working_dir")
+                self.stored_timeout = kwargs.get("timeout_minutes")
+
+            def run(self) -> int:
+                return 0
+
+        action = FrameworkAction(
+            "test",
+            context_with_vars,
+            id="step1",
+            working_dir="/path/${{ matrix.item }}",  # Should NOT be interpolated
+            timeout_minutes=30,
+        )
+        # Framework kwargs should not be interpolated
+        assert action.stored_working_dir == "/path/${{ matrix.item }}"
+        assert action.stored_timeout == 30
+
+    def test_non_string_types_preserved(self, context_with_vars):
+        """Test that non-string types are preserved"""
+
+        class TypeAction(Action):
+            def __init__(self, name, context, **kwargs):
+                super().__init__(name, context, **kwargs)
+                self.bool_param = kwargs.get("fail_on_diff")
+                self.int_param = kwargs.get("floor")
+                self.float_param = kwargs.get("tolerance")
+                self.none_param = kwargs.get("optional")
+
+            def run(self) -> int:
+                return 0
+
+        action = TypeAction(
+            "test",
+            context_with_vars,
+            id="step1",
+            fail_on_diff=True,
+            floor=1.5,
+            tolerance=1e-6,
+            optional=None,
+        )
+        assert action.bool_param is True
+        assert action.int_param == 1.5
+        assert action.float_param == 1e-6
+        assert action.none_param is None
+
+    def test_no_context_skips_interpolation(self):
+        """Test that when context is None, no interpolation happens"""
+
+        class NoContextAction(Action):
+            def __init__(self, name, context, **kwargs):
+                super().__init__(name, context, **kwargs)
+                self.test_param = kwargs.get("reference")
+
+            def run(self) -> int:
+                return 0
+
+        action = NoContextAction(
+            "test",
+            None,
+            id="step1",
+            reference="${{ undefined }}",
+        )
+        # Without context, the parameter should remain unchanged
+        assert action.test_param == "${{ undefined }}"
+
+    def test_step_output_interpolation(self, context_with_vars):
+        """Test interpolation using step output variables"""
+        context_with_vars.vars["steps"]["prev"] = {"output": "result_123"}
+
+        class StepRefAction(Action):
+            def __init__(self, name, context, **kwargs):
+                super().__init__(name, context, **kwargs)
+                self.input_file = kwargs.get("input_file")
+
+            def run(self) -> int:
+                return 0
+
+        action = create_action_with_interpolation(
+            StepRefAction,
+            "test",
+            context_with_vars,
+            id="step2",
+            input_file="/tmp/${{ steps.prev.output }}.txt",
+        )
+        assert action.input_file == "/tmp/result_123.txt"

--- a/tests/test_shell_action.py
+++ b/tests/test_shell_action.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from kuristo.actions.shell_action import ShellAction
 from kuristo.context import Context
@@ -10,25 +10,21 @@ def make_context(vars_dict=None):
     return ctx
 
 
-def test_create_command_calls_interpolate_str():
+def test_create_command_returns_preinterpolated_value():
     ctx = make_context({"name": "world"})
-    with patch(
-        "kuristo.actions.shell_action.interpolate_str", return_value="echo world"
-    ) as mock_interp:
-        action = ShellAction("test", ctx, commands="echo {name}")
-        result = action.create_command()
-        mock_interp.assert_called_once_with("echo {name}", ctx.vars)
-        assert result == "echo world"
-
-
-def test_create_command_real_interpolation():
-    # We'll simulate interpolate_str's actual effect for realism
-    # from kuristo.actions.shell_action import interpolate_str
-    ctx = make_context({"name": "Alice"})
-    action = ShellAction("test", ctx, commands="echo ${{name}}")
+    # Command is already interpolated by ActionFactory before being passed to ShellAction
+    action = ShellAction("test", ctx, commands="echo world")
     result = action.create_command()
-    # This assumes interpolate_str uses str.format or similar
-    assert "Alice" in result
+    assert result == "echo world"
+
+
+def test_create_command_with_list_commands():
+    # ShellAction can receive either string or list commands
+    ctx = make_context({})
+    cmd_list = ["echo", "hello", "world"]
+    action = ShellAction("test", ctx, commands=cmd_list)
+    result = action.create_command()
+    assert result == cmd_list
 
 
 def test_create_command_no_context_raises():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Action creation now performs consistent interpolation of parameters and commands (strings inside nested lists/dicts are supported); interpolation errors leave originals unchanged.

* **Bug Fixes**
  * Shell and MPI actions now receive already-resolved commands/params at creation time, preventing double or in-action interpolation.

* **Tests**
  * Added and updated tests validating interpolation behavior across strings, lists, dicts, framework kwargs, non-string types, and no-context cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->