### PR TITLE
Stream output from Popen into a temporary file rather then a pipe

### DIFF
--- a/kuristo/actions/process_action.py
+++ b/kuristo/actions/process_action.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import tempfile
 from abc import abstractmethod
 
 import kuristo.utils as utils
@@ -31,31 +32,36 @@ class ProcessAction(Action):
             env.update(self.context.env)
         env.update((var, str(val)) for var, val in self._env.items())
         cmd, use_shell = utils.determine_shell_use(self.command)
-        self._process = subprocess.Popen(
-            cmd,
-            shell=use_shell,
-            cwd=self.working_directory,
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
-        try:
-            stdout, _ = self._process.communicate(timeout=timeout * 60)
-            if self.id is not None:
-                self.context.vars["steps"][self.id] = {"output": stdout.decode()}
-            self.output = stdout
-            return self._process.returncode
+        with tempfile.TemporaryFile() as tmp_file:
+            self._process = subprocess.Popen(
+                cmd,
+                shell=use_shell,
+                cwd=self.working_directory,
+                env=env,
+                stdout=tmp_file,
+                stderr=subprocess.STDOUT,
+            )
+            try:
+                self._process.communicate(timeout=timeout * 60)
 
-        except subprocess.TimeoutExpired:
-            self.terminate()
-            outs, _ = self._process.communicate()
-            outs += b"\n"
-            outs += "Step timed out".encode()
-            self.output = outs
-            return 124
-        except subprocess.SubprocessError:
-            self.output = b""
-            return -1
+                tmp_file.seek(0)
+                stdout = tmp_file.read()
+
+                if self.id is not None:
+                    self.context.vars["steps"][self.id] = {"output": stdout.decode()}
+                self.output = stdout
+                return self._process.returncode
+
+            except subprocess.TimeoutExpired:
+                self.terminate()
+                outs, _ = self._process.communicate()
+                outs += b"\n"
+                outs += "Step timed out".encode()
+                self.output = outs
+                return 124
+            except subprocess.SubprocessError:
+                self.output = b""
+                return -1
 
     def terminate(self):
         if self._process is not None:

--- a/tests/test_process_action.py
+++ b/tests/test_process_action.py
@@ -26,9 +26,15 @@ def action_instance():
 
 def test_successful_run(action_instance):
     mock_popen = MagicMock()
-    mock_popen.communicate.return_value = (b"output", None)
     mock_popen.returncode = 0
-    with patch("subprocess.Popen", return_value=mock_popen):
+
+    def mock_popen_side_effect(*args, **kwargs):
+        stdout_file = kwargs.get("stdout")
+        if stdout_file:
+            stdout_file.write(b"output")
+        return mock_popen
+
+    with patch("subprocess.Popen", side_effect=mock_popen_side_effect):
         exit_code = action_instance.run()
         assert exit_code == 0
     assert action_instance.output == "output"


### PR DESCRIPTION
We see processes finish with return code -13 (SIGPIPE - referred to as a "Broken Pipe").  This is (as GEMINI says) caused by a slight race condition between `mpirun` and our PIPE created via Popen:

> 1. The main MPI worker processes finish their calculations and flush
>    their final output.
> 2. Python reads this data, sees the standard EOF indicators from the
>    primary threads, and wraps up communicate(), instantly closing the
>    pipe file descriptor.
> 3. Meanwhile, mpirun's background daemon, a local rank cleanup routine,
>    or an internal MPI logging teardown thread wakes up to write its
>    final exit statistics or cleanup logs to stdout.
> 4. Because Python already tore down and closed the pipe, mpirun
>    encounters a closed file descriptor, triggers a SIGPIPE, and
>    terminates with exit code -13.

Suggested fix (by GEMINI):

> When you stream output to an actual physical file on the disk, a
> SIGPIPE is physically impossible because there is no reader process
> closing an active stream channel.